### PR TITLE
Support `manualOrdering` for elimination stages

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -103,7 +103,10 @@ export interface StageSettings {
     roundRobinMode?: RoundRobinMode,
 
     /**
-     * A list of seeds per group for a round-robin stage to be manually ordered.
+     * A list of seeds to manually order the stage.
+     *
+     * - For a round-robin stage: a list of seeds per group.
+     * - For an elimination stage: a single list of seeds for the bracket.
      *
      * Seed ordering is ignored if this property is given.
      */

--- a/src/input.ts
+++ b/src/input.ts
@@ -59,7 +59,7 @@ export interface InputStage {
  */
 export interface StageSettings {
     /**
-     * The number of participants.
+     * The number of participants in the stage.
      */
     size?: number,
 


### PR DESCRIPTION
Closes Drarig29/brackets-manager.js#232

Updates `manualOrdering` JSDoc to document support for elimination stages (single list of seeds for the bracket), in addition to the existing round-robin behavior (list of seeds per group).

See Drarig29/brackets-manager.js#234 for the corresponding implementation.